### PR TITLE
Updating links and organizing next post

### DIFF
--- a/content/posts/01-post.md
+++ b/content/posts/01-post.md
@@ -87,5 +87,5 @@ https://github.com/chris-crone/containerized-go-dev
 
 ## Grabacion de la sesion
 Con fallo de principiante, solo no grabe el audio del resto, solo el que salia de mi equipo.
-- https://www.youtube.com/watch?v=yS1d4oQW66k
-- https://www.ivoox.com/podcast-equilibrist-of-go_sq_f11669874_1.html
+- [youtube](https://www.youtube.com/watch?v=yS1d4oQW66k)
+- [ivoox](https://www.ivoox.com/podcast-equilibrist-of-go_sq_f11669874_1.html)

--- a/content/posts/02-post.md
+++ b/content/posts/02-post.md
@@ -40,7 +40,7 @@ por tanto si queremos almacenar mas de una... debemos aprovechar almacenar estru
     - Un ejemplo sencillo de como se almacenan y se estraen los elementos del contexto, a partir de ahi podemos usar el contexto como parametro entre metodos para hacerlo viajar asegurando su consistencia.
     - En el segundo ejemplo, vemos como podemos extender un contexto en otro, y acceder al contexto nativo a traves de otras implementaciones (a parte de ver como implementar un middleware proxy).
 
-## Visibilidades dentro y fuera de un paquete para los atributos
+## Visibilidades dentro y fuera de un paquete para los atributos {#visibilidad}
 Basicamente la regla se resume en, si esta en mayuscula ... es visible, pero sino, no... y eso aplica a todo, metodos, atributos...
 
 ```
@@ -90,7 +90,7 @@ relacionar el codigo go con c y viceversa.
 
 ## Breves
 
-### code generator
+### code generator {#code_generator}
 La generación de código (antes claro esta de la aparición de ChatGPT) siempre ha sido una opción para ciertas casuísticas, y tampoco tiene que ser mal mirado, puedes necesitar repetir ciertos soluciones en distintos lugares, por distintos motivos...
 
 - [A Yeoman Generator to Scaffold Golang-project](https://morioh.com/p/90906ca5c28e) Yeoman es una solución para generar proyectos de código completo siguiendo plantillas, como Helm para generar deployments en Kubernetes.
@@ -109,3 +109,8 @@ La generación de código (antes claro esta de la aparición de ChatGPT) siempre
 - Clasicos - Emacs
     - [emacs-lsp-go](https://geeksocket.in/posts/emacs-lsp-go/)
     - [emacs tour](https://dr-knz.net/a-tour-of-emacs-as-go-editor.html)
+
+## Grabacion de la sesion
+Pues con el experimento asincrono, y sin nadie que se animara a las preguntas...
+- [youtube](https://youtu.be/oiZLKqO72P0)
+- [ivoox](https://go.ivoox.com/rf/108219339)

--- a/content/posts/03-post.md
+++ b/content/posts/03-post.md
@@ -1,37 +1,15 @@
 ---
 title: "Third Lightning Talk"
-date: 2030-01-01T19:00:00+02:00
+date: 2023-06-02T19:00:00+02:00
 draft: true
 ---
 
 # Temas a tratar en la tercera sesión
 
-## Mutex
-En golang existe el patron CSP que facilita mucho la concurrencia, pero de el hablaremos otro dia, hoy simplemente nos quedamos con los mutex, que nos permiten sincronizar bloques de codigo usando objetos que permiten el bloqueo de lectura o lectura/escritura.
-
-...
-
-### Ejemplos de código 
-- La idea de estos ejemplos, es ver como con un ejemplo de codigo simplificado podemos pasar de:
-    - La necesidad de sincronizar el acceso a variables comunes, descubierto por unos test unitarios, corridos para detectar "race condition"
-    - ...
-    - Ha como se puede reorganizar el codigo para dejar de usar los mutex y pasar al enfoque CSP.
-    - Puedes ver la evolucion [aqui](https://github.com/equilibristofgo/sandbox/tree/feat/mutex_example/05_race_condition)
-
-## Testing api rest
-Golang tiene bien integrado en sus bases el mundo del testing, y para test de APIS rest, existe una utilidad para poder moquear los servidores de tal forma que podamos probar facilmente esas apis.
-
-Como ejemplo de proxy, realizado por la comunidad, tenemos a parte de los clasicos... a Killgrave.
-
-- Links a organizar
-    - https://github.com/intercloud/venom/tree/executor-tavern/executors/tavern
-    - https://github.com/friendsofgo/killgrave 
-
-### Ejemplos de código 
-- [Aqui]()
-
 ## Paquetería interna no exportable en go
-Aqui el tema esta, no solo para atributos sino paquetes enteros.
+En la sesión anterior hablamos sobre la [visibilidad]({{< ref "02-post#visibilidad" >}}) de los atributos. En este bloque hablaremos sobre la visibilidad de paquetes enteros...
+
+...para ello aprovecharemos a ver varios tipos de organizaciones clasiscas de paquetes, y como no podemos usar ciertos paquetes en otros...
 
 - Links a organizar
     - https://stackoverflow.com/questions/59342373/use-of-internal-package-not-allowed
@@ -41,6 +19,8 @@ Aqui el tema esta, no solo para atributos sino paquetes enteros.
 
 ### Ejemplos de código 
 - [Aqui](https://github.com/equilibristofgo/sandbox/tree/main/04_internal/app)
+
+
 
 ## Gopls y los monorepos (con VSCode y muchos módulos Bazel y uno solo go.mod)
 Cuando tu proyecto es un monorepo gigante, todo empieza a ralentizarse ¿por que?. La idea es tratar de ver como se comporta el IDE (que en el caso de GoLang) suele delegar en Gopls.
@@ -59,4 +39,44 @@ Cuando tu proyecto es un monorepo gigante, todo empieza a ralentizarse ¿por que
     - https://stackoverflow.com/questions/55411277/how-can-i-setup-vscode-for-go-project-built-with-bazel
 
 ### Ejemplos de código 
+- [Aqui](https://github.com/equilibristofgo/sandbox/tree/main/12_gopls)
+
+
+
+## Go Generate
+En la sesion anterior estuvimos hablando de [Code Generator]({{< ref "02-post#code_generator" >}}) y vimos por encima algunas herramientas...
+
+...veamos ahora una opcion nativa en go para generar codigo...
+
+- Links a organizar
+    - https://ehrt74.medium.com/go-generate-89b20a27f7f9
+
+### Ejemplos de código 
+- [Aqui](https://github.com/equilibristofgo/sandbox/tree/main/11_generate)
+
+
+
+## Testing api rest
+Golang tiene bien integrado en sus bases el mundo del testing, y para test de APIS rest, existe una utilidad para poder moquear los servidores de tal forma que podamos probar facilmente esas apis.
+
+...Como ejemplo de proxy, realizado por la comunidad, tenemos a parte de los clasicos... a Killgrave.
+
+- Links a organizar
+    - https://github.com/intercloud/venom/tree/executor-tavern/executors/tavern
+    - https://github.com/friendsofgo/killgrave 
+
+### Ejemplos de código 
 - [Aqui]()
+
+
+
+## Breves
+
+### sort
+https://pkg.go.dev/sort#example-package-SortKeys
+
+
+## Grabacion de la sesion
+...
+- [youtube]()
+- [ivoox]()

--- a/content/posts/04-post.md
+++ b/content/posts/04-post.md
@@ -6,10 +6,16 @@ draft: true
 
 # Temas a tratar en la cuarta sesión
 
-## Charla interesante en una conferencia
-- Temas interesantes a revisar desde una charla de conferencia
-  - https://dave.cheney.net/practical-go/presentations/qcon-china.html
-  - https://www.youtube.com/channel/UCJ6wWvwujWtWegn4F69syZw/search?query=real
+## Mutex
+En golang existe el patron CSP que facilita mucho la concurrencia, pero de el hablaremos otro dia, hoy simplemente nos quedamos con los mutex, que nos permiten sincronizar bloques de codigo usando objetos que permiten el bloqueo de lectura o lectura/escritura.
+...
+
+### Ejemplos de código 
+- La idea de estos ejemplos, es ver como con un ejemplo de codigo simplificado podemos pasar de:
+    - La necesidad de sincronizar el acceso a variables comunes, descubierto por unos test unitarios, corridos para detectar "race condition"
+    - ...
+    - Ha como se puede reorganizar el codigo para dejar de usar los mutex y pasar al enfoque CSP.
+    - Puedes ver la evolucion [aqui](https://github.com/equilibristofgo/sandbox/tree/feat/mutex_example/05_race_condition)
 
 ## Transaccionalidad de operaciones
 Si en un proyecto tienes microservicios de orquestación que por ejemplo actualizan datos en dos bases de datos, cada una de un micro distinto? Si quieres garantizar la coherencia de datos entre esas dos bases de datos. Si la primera llamada al micro1 va bien y la Segunda falla al micro2 que haces con los datos del micro1.. la pregunta de siempre jaja

--- a/content/posts/05-post.md
+++ b/content/posts/05-post.md
@@ -6,7 +6,11 @@ draft: true
 
 # Temas a tratar en la sesión 05
 
-## Versionado/releasing en golang
+
+## Charla interesante en una conferencia
+- Temas interesantes a revisar desde una charla de conferencia
+  - https://dave.cheney.net/practical-go/presentations/qcon-china.html
+  - https://www.youtube.com/channel/UCJ6wWvwujWtWegn4F69syZw/search?query=real
 
 ## Modelos (moldes para magdalenas)... Cuidado con los alérgicos al gluten 😅
 

--- a/content/posts/06-post.md
+++ b/content/posts/06-post.md
@@ -31,7 +31,6 @@ https://softwareengineering.stackexchange.com/questions/361649/are-cqrs-and-hexa
 https://softwareengineering.stackexchange.com/questions/360850/where-should-i-place-configuration-classes-in-onion-architecture/360912#360912
 https://martinfowler.com/bliki/CQRS.html
 
+## Versionado/releasing en golang
 
-## sort
-https://pkg.go.dev/sort#example-package-SortKeys
 

--- a/content/posts/livekit_telegram.md
+++ b/content/posts/livekit_telegram.md
@@ -144,4 +144,4 @@ Para lo que se necesita un [Redis](https://redis.io/docs/getting-started/install
 
 ## Grabacion de la sesion
 Aunque se oye muy bajito, aqui queda algo del experimento...
-- https://youtu.be/svwN0O6WGcs
+- [youtube](https://youtu.be/svwN0O6WGcs)


### PR DESCRIPTION
- Creating links (in markdown style) of videos ... including 02-post, the last...
- Adding anchors in 02-post to use in the next 03-post
- Organizing 03 to reference things from latest and inprove in the nex
1. We talked about visibility of attributes ... now talk about package visibility
2. In "Breves" talk about Code Generator... now talk about "generate" inside golang
- Use 04_internal to 12_gopls base to build multiple package to simulate monorepo
- Organize the next "WIP" session orders